### PR TITLE
Add more packages required to build/install wal-e

### DIFF
--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -7,6 +7,8 @@
     - lzop
     - pv
     - python-pip
+    - python-dev
+    - python-lxml
 
 - name: Install requirements - pt. 2
   pip: name=wal-e


### PR DESCRIPTION
Thanks for the excellent playbook!

I had to add the following packages to get some of wal-e's dependencies to build on my system.
