### PR TITLE
Tightens runscript permissions, grammar fixes.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,25 +3,25 @@
 wale_enabled: yes                     # The role is enabled
 wale_remove: no                       # Uninstall the role
 
-wale_home: /etc/wale                  # Where make runscript
-wale_logdir: /var/log/wale            # Where store logs
+wale_home: /etc/wale                  # Where to place runscript
+wale_logdir: /var/log/wale            # Where to store logs
 wale_user: "postgres"
 wale_group: "postgres"
 wale_cron: []                          # Setup cronjobs
                                        # Ex. wale_cron:
                                        #     - { schedule: * * * * *, cmd: backup-push /var/lib/postgresql/9.1/main/ }
 
-# Set the credentials for enable upload to AWS S3
-wale_aws_access_key_id:               
+# Set these credentials to enable upload to AWS S3
+wale_aws_access_key_id:
 wale_aws_secret_access_key:
 wale_aws_s3_prefix:
 
-# Set the credentials for enable upload to WABS
-wale_wabs_account_name:               
+# Set these credentials to enable upload to WABS
+wale_wabs_account_name:
 wale_wabs_access_key:
 wale_wabs_prefix:
 
-# Set the credentials for enable upload to SWIFT
+# Set these credentials to enable upload to SWIFT
 wale_swift_authurl:
 wale_swift_tenant:
 wale_swift_user:

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -4,7 +4,7 @@
   user: name={{ wale_user }}
 - group: name={{ wale_group }}
 
-- name: Ensure wale home is exists
+- name: Ensure wale home exists
   file: >
     group={{ wale_group }}
     owner={{ wale_user }}
@@ -16,7 +16,7 @@
   template: >
     dest={{ wale_home }}/wale.sh
     group={{ wale_group }}
-    mode=744
+    mode=0750
     owner={{ wale_user }}
     src=wale.sh.j2
 

--- a/templates/wale.sh.j2
+++ b/templates/wale.sh.j2
@@ -47,7 +47,7 @@ status() {
 case "$1" in
 
     status)
-        status && echo "Wal-e running." || echo "Wal-e doesnt running."
+        status && echo "Wal-e running." || echo "Wal-e not running."
         ;;
 
     backup-push)


### PR DESCRIPTION
It's likely that other users shouldn't be able to read the wal-e
runscript, as it contains sensitive storage backend credentials.
However, if the wal-e user should be able to execute the script,
it seems sensible that the wal-e group should be able to do so as
well.