### PR TITLE
Install latest version of six to avoid wal-e errors

### DIFF
--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -11,4 +11,7 @@
     - python-lxml
 
 - name: Install requirements - pt. 2
-  pip: name=wal-e
+  pip: name={{item}} state=latest
+  with_items:
+    - six
+    - wal-e


### PR DESCRIPTION
wal-e throws an error if the installed version of the python "six" package is not >= 1.7.0, which is currently occurring when installing wal-e.

This fix causes wal-e to work as expected when installed via this playbook, instead of throwing an error. It can be removed later if wal-e fixes it upstream.

Related issue here: https://github.com/wal-e/wal-e/issues/143
