### PR TITLE
Only locks backup-push and backup-fetch, fixes delete bug, better locking via flock

### DIFF
--- a/templates/wale.sh.j2
+++ b/templates/wale.sh.j2
@@ -27,13 +27,25 @@ echo "Please setup Wal-e settings in the role" 1>&2
 exit 2
 {% endif %}
 
+_do_wale_locked() {
+    # Re-execute this script under flock if $FLOCK is empty/undefined. This
+    # creates the lockfile if necessary.
+    if [ -z "$FLOCK" ] ; then
+        LOCKOPTS="-w 0 $LOCKFILE"
+        exec env FLOCK=1 flock $LOCKOPTS $0 "$@"
+    fi
+
+    _do_wale $1 $2 $3
+    RETVAL=$?
+    rm -f $LOCKFILE
+    return $RETVAL
+}
+
 _do_wale() {
-    touch $LOCKFILE
     # Using tee -a instead of >> so we can additionally pipe output somewhere
     # else, if desired.
     $WALE $1 $2 $3 2>&1 | tee -a $LOGFILE
     RETVAL=$?
-    rm -f $LOCKFILE
     return $RETVAL
 }
 
@@ -53,13 +65,11 @@ case "$1" in
         ;;
 
     backup-push)
-        status && exit 0
-        _do_wale $1 $2 $3
+        _do_wale_locked $1 $2 $3
         ;;
 
     backup-fetch)
-        status && exit 0
-        _do_wale $1 $2 $3
+        _do_wale_locked $1 $2 $3
         ;;
 
     backup-list)
@@ -67,17 +77,15 @@ case "$1" in
         ;;
 
     wal-push)
-        status && exit 0
         _do_wale $1 $2 $3
         ;;
 
     wal-fetch)
-        status && exit 0
         _do_wale $1 $2 $3
         ;;
 
     *)
-        echo "Usage: $0 {backup-push|backup-fetch|backup-list|wall-push|wall-fetch|status}"
+        echo "Usage: $0 {backup-push|backup-fetch|backup-list|wal-push|wal-fetch|status}"
         exit 2
 
 esac

--- a/templates/wale.sh.j2
+++ b/templates/wale.sh.j2
@@ -6,22 +6,22 @@
 WALE=/usr/local/bin/wal-e
 LOCKFILE=/var/lock/wale
 LOGFILE={{ wale_logdir }}/wale.log
-[ -f $LOGGILE ] || touch $LOGFILE
+[ -f $LOGFILE ] || touch $LOGFILE
 
 {% if wale_aws_access_key_id and wale_aws_secret_access_key and wale_aws_s3_prefix %}
-export AWS_ACCESS_KEY_ID={{ wale_aws_access_key_id }}
-export AWS_SECRET_ACCESS_KEY={{ wale_aws_secret_access_key }}
-export WALE_S3_PREFIX={{ wale_aws_s3_prefix }}
+export AWS_ACCESS_KEY_ID='{{ wale_aws_access_key_id }}'
+export AWS_SECRET_ACCESS_KEY='{{ wale_aws_secret_access_key }}'
+export WALE_S3_PREFIX='{{ wale_aws_s3_prefix }}'
 {% elif wale_wabs_account_name and wale_wabs_access_key and wale_wabs_prefix %}
-export WABS_ACCOUNT_NAME={{ wale_wabs_account_name }}
-export WABS_ACCESS_KEY={{ wale_wabs_access_key }}
-export WALE_WABS_PREFIX={{ wale_wabs_prefix }}
+export WABS_ACCOUNT_NAME='{{ wale_wabs_account_name }}'
+export WABS_ACCESS_KEY='{{ wale_wabs_access_key }}'
+export WALE_WABS_PREFIX='{{ wale_wabs_prefix }}'
 {% elif wale_swift_authurl and wale_swift_tenant and wale_swift_user and wale_swift_password and wale_swift_prefix %}
-export SWIFT_AUTHURL={{ wale_swift_authurl }}
-export SWIFT_TENANT={{ wale_swift_tenant }}
-export SWIFT_USER={{ wale_swift_user }}
-export SWIFT_PASSWORD={{ wale_swift_password }}
-export WALE_SWIFT_PREFIX={{ wale_swift_prefix }}
+export SWIFT_AUTHURL='{{ wale_swift_authurl }}'
+export SWIFT_TENANT='{{ wale_swift_tenant }}'
+export SWIFT_USER='{{ wale_swift_user }}'
+export SWIFT_PASSWORD='{{ wale_swift_password }}'
+export WALE_SWIFT_PREFIX='{{ wale_swift_prefix }}'
 {% else %}
 echo "Please setup Wal-e settings in the role" 1>&2
 exit 2
@@ -35,7 +35,7 @@ _do_wale_locked() {
         exec env FLOCK=1 flock $LOCKOPTS $0 "$@"
     fi
 
-    _do_wale $1 $2 $3
+    _do_wale $@
     RETVAL=$?
     rm -f $LOCKFILE
     return $RETVAL
@@ -44,7 +44,7 @@ _do_wale_locked() {
 _do_wale() {
     # Using tee -a instead of >> so we can additionally pipe output somewhere
     # else, if desired.
-    $WALE $1 $2 $3 2>&1 | tee -a $LOGFILE
+    $WALE $@ 2>&1 | tee -a $LOGFILE
     RETVAL=$?
     return $RETVAL
 }
@@ -65,11 +65,11 @@ case "$1" in
         ;;
 
     backup-push)
-        _do_wale_locked $1 $2 $3
+        _do_wale_locked $@
         ;;
 
     backup-fetch)
-        _do_wale_locked $1 $2 $3
+        _do_wale_locked $@
         ;;
 
     backup-list)
@@ -77,16 +77,15 @@ case "$1" in
         ;;
 
     wal-push)
-        _do_wale $1 $2 $3
+        _do_wale $@
         ;;
 
     wal-fetch)
-        _do_wale $1 $2 $3
+        _do_wale $@
         ;;
 
     delete)
-        status && exit 0
-        _do_wale $1 $2 $3 $4
+        _do_wale $@
         ;;
 
     *)


### PR DESCRIPTION
The previous locking mechanism (just creating/deleting a file) wouldn't handle cases where the process is killed abruptly (and thus doesn't delete the lock file itself), whereas using `flock` for locking resolves this.

As per issue #5, it makes sense to wrap backup-push and backup-fetch in a lock, but it doesn't make sense to wrap `wal-push` in locking, as doing so can make `wal-push` fail while a `backup-push` is in progress. This is even more problematic if the `backup-push` operation takes a particularly long time to complete.

The `delete` command wasn't working, as `_do_wale()` wasn't passing its fourth positional argument on to `$WALE`. This has been resolved, in general, by passing `$@` to `$WALE` instead of `$1 $2 $3` ... etc
This seems preferable to me, as it means this role isn't as coupled to the specifics of the WAL-E command-line interface.

Also quotes `wal-e.sh` environment variables just in case, and fixes typo (`$LOGGILE` -> `$LOGFILE`).